### PR TITLE
feat: add 0x7C( | ) to terminator chars

### DIFF
--- a/lib/rules_inline/text.js
+++ b/lib/rules_inline/text.js
@@ -35,6 +35,7 @@ function isTerminatorChar(ch) {
     case 0x60/* ` */:
     case 0x7B/* { */:
     case 0x7D/* } */:
+    case 0x7C/* | */:
     case 0x7E/* ~ */:
       return true;
     default:


### PR DESCRIPTION
for support new `||` syntax