### PR TITLE
fix: handle line offset in block quote correctly

### DIFF
--- a/lib/rules_block/blockquote.js
+++ b/lib/rules_block/blockquote.js
@@ -278,12 +278,17 @@ module.exports = function blockquote(state, startLine, endLine, silent) {
   for (i = 0; i < oldTShift.length; i++) {
     const lineNumber = i + startLine;
     if (state.lineOffsets[lineNumber] === null) {
-      state.lineOffsets[lineNumber] = totalLineOffset;
+      if (i === 0) {
+        // first line of blockquote
+        state.lineOffsets[lineNumber] = 0;
+        continue;
+      }
       if (isNotEmptyLine(state, lineNumber)) {
         totalLineOffset += calcLineOffset(state, lineNumber);
       } else {
         totalLineOffset = 0;
       }
+      state.lineOffsets[lineNumber] = totalLineOffset;
     }
 
     state.bMarks[lineNumber] = oldBMarks[i];


### PR DESCRIPTION
Adjust the calculation order of lineOffsets summation to prevent errors in special cases
(e.g., when there is no space between the first line blockquote and the content)

before patch
```
>a   -> lineOffset: 0
> b  -> lineOffset: 1 (should be 2)
> c  -> lineOffset: 3 (should be 4)
```

after patch
```
>a   -> lineOffset: 0
> b  -> lineOffset: 2
> c  -> lineOffset: 4
```